### PR TITLE
add /wiki/api.php as candidate API URL

### DIFF
--- a/src/collect.js
+++ b/src/collect.js
@@ -9,6 +9,7 @@ let apiLocations = {
     "/w/api.php": ["wikipedia.org", "wikimedia.org"],
     "/api.php": ["fandom.com"],
     "/mediawiki/api.php": [],
+    "/wiki/api.php": [],
 }
 
 export async function apiURL(domain) {


### PR DESCRIPTION
It's used by a wiki I tried to browse (https://indieweb.org) and googling for the path also found other wikis with the same, so I think it's a good candidate to include.